### PR TITLE
Update awsAuth method to accept options, including Vault role

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ NodeJS API client for HashiCorp's [Vault]
 
     # yarn
     yarn add node-vault
-    
+
     # npm
     npm install node-vault
 
@@ -56,6 +56,21 @@ const run = async () => {
   await vault.write('secret/hello', { value: 'world', lease: '1s' })
   await vault.read('secret/hello')
   await vault.delete('secret/hello')
+}
+
+run().catch(console.error)
+```
+
+### Login with AWS
+
+```javascript
+const run = async () => {
+  const awsAuthOptions = {
+    // If your Vault role name differs from your IAM role name, specify the Vault role here:
+    vaultRole: 'my-vault-role'
+  }
+  const vault = await require('node-vault').awsAuth(awsAuthOptions);
+  console.log(await vault.read('secret/something'))
 }
 
 run().catch(console.error)

--- a/src/aws-auth.js
+++ b/src/aws-auth.js
@@ -72,9 +72,15 @@ const getSignedEc2IamRequest = async () => {
   }
 }
 
-const awsEc2IamLogin = async (vault) => {
+const awsEc2IamLogin = async (vault, options) => {
   // execute login operation
   const request = await getSignedEc2IamRequest()
+  // the role to use with Vault might be different than the role used by AWS
+  if (options && options.vaultRole) {
+    request.role = options.vaultRole
+  } else if (process.env.VAULT_ROLE) {
+    request.role = process.env.VAULT_ROLE
+  }
   const authResult = await vault.awsIamLogin(request)
 
   // login with the returned token into node-vault

--- a/src/aws-auth.js
+++ b/src/aws-auth.js
@@ -72,15 +72,12 @@ const getSignedEc2IamRequest = async () => {
   }
 }
 
-const awsEc2IamLogin = async (vault, options) => {
+const awsEc2IamLogin = async (vault, options = {}) => {
   // execute login operation
   const request = await getSignedEc2IamRequest()
   // the role to use with Vault might be different than the role used by AWS
-  if (options && options.vaultRole) {
-    request.role = options.vaultRole
-  } else if (process.env.VAULT_ROLE) {
-    request.role = process.env.VAULT_ROLE
-  }
+  request.role = options.vaultRole || process.env.VAULT_ROLE || request.role
+
   const authResult = await vault.awsIamLogin(request)
 
   // login with the returned token into node-vault

--- a/src/main.js
+++ b/src/main.js
@@ -313,10 +313,10 @@ class VaultClient {
 const nodeVault = options => new VaultClient(options).client
 
 // add aws authentication helper
-nodeVault.awsAuth = async () => {
+nodeVault.awsAuth = async (options) => {
   // creates a logged in instance of node-vault
   const vault = nodeVault()
-  return awsAuth(vault)
+  return awsAuth(vault, options)
 }
 
 module.exports = nodeVault


### PR DESCRIPTION
The `aws-auth` branch assumes that the name of the IAM role is identical to the name of the role in Vault. This isn’t necessarily the case.

This PR allows the `awsAuth` method to accept an options object, which currently has only one setting that can be specified: `vaultRole`, to define the name of the role to use when connecting to Vault. There’s no need to define the IAM role since that’s retrieved dynamically. The `awsAuth` method also looks for a `VAULT_ROLE` environment variable as a fallback. If the environment variable isn’t set, and the options object is undefined or lacks the `vaultRole` key, the current behavior remains.

I also added an example to the README.