### PR TITLE
Support Vault login using ECS container credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-vault",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "NodeJS API client for HashiCorp's Vault",
   "main": "./src/main.js",
   "scripts": {


### PR DESCRIPTION
This updates the AWS login to use Elastic Container Service credentials if it detects that we’re in an ECS container, otherwise fall back to the EC2 credentials.

Generally you want to use the IAM role assigned to your container, rather than assigned to the overall EC2 instance (if there even is one on the EC2 host for ECS containers) because the various ECS containers on a host might not all be for the same app and therefore might have different permissions.